### PR TITLE
remove capitalize text transformation in the modal message paragraph

### DIFF
--- a/src/components/GeneralModal/styles.js
+++ b/src/components/GeneralModal/styles.js
@@ -26,7 +26,11 @@ const useStyles = makeStyles(() => ({
       fontFamily: 'Poppins',
       color: 'gray',
       fontSize: '16px',
+      textTransform: 'lowercase',
       textAlign: 'center',
+    },
+    '&  > p::first-letter': {
+      textTransform: 'capitalize',
     },
   },
   buttonGrad: {

--- a/src/components/GeneralModal/styles.js
+++ b/src/components/GeneralModal/styles.js
@@ -26,7 +26,6 @@ const useStyles = makeStyles(() => ({
       fontFamily: 'Poppins',
       color: 'gray',
       fontSize: '16px',
-      textTransform: 'capitalize',
       textAlign: 'center',
     },
   },


### PR DESCRIPTION
remove capitalize text transformation in the modal message paragraph 

![image](https://user-images.githubusercontent.com/83250801/128755222-056c0078-169f-47d6-b6fa-9cc45a7268f7.png)
![image](https://user-images.githubusercontent.com/83250801/128755283-67ebdbff-59e1-4850-b382-fcf73707e611.png)
